### PR TITLE
Revert return type of H, V, S matrix

### DIFF
--- a/vsexprtools/exprop.py
+++ b/vsexprtools/exprop.py
@@ -260,7 +260,7 @@ class ExprOp(ExprOpBase, CustomEnum):
     @classmethod
     def matrix(
         cls, var: str | ExprVarsT, radius: int, mode: ConvMode, exclude: Iterable[tuple[int, int]] | None = None
-    ) -> TupleExprList:
+    ) -> ExprList | TupleExprList:
         exclude = list(exclude) if exclude else list()
 
         match mode:
@@ -290,12 +290,12 @@ class ExprOp(ExprOpBase, CustomEnum):
             case _:
                 raise NotImplementedError
 
-        return TupleExprList([ExprList([
+        return ExprList([
             var if x == y == 0 else
             ExprOp.REL_PIX(var, x, y)
             for (x, y) in coordinates
             if (x, y) not in exclude
-        ])])
+        ])
 
     @classmethod
     def convolution(


### PR DESCRIPTION
https://github.com/Jaded-Encoding-Thaumaturgy/vs-exprtools/commit/51a25119473c83b9c8c8074b31ee3bc2fcdaf4f0 changed the return type of `ExprOp.matrix` to always be a `TupleExprList`. However, this breaks other functions that depend on the return type being an `ExprList` for modes Square, H, and V.

Partially fixes #23.